### PR TITLE
Update versions of Go and add additional builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,19 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -13,4 +26,4 @@ jobs:
         with:
           go-version: 1.26
       - name: Build rdapq
-        run: GOOS=linux GOARCH=amd64 go build rdapq.go
+        run: GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build rdapq.go

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,6 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
-          go-version: 1.25
+          go-version: 1.26
       - name: Build rdapq
         run: GOOS=linux GOARCH=amd64 go build rdapq.go

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kadonnelly13/rdapq
 
-go 1.25
+go 1.26


### PR DESCRIPTION
- Update Go 1.25 -> 1.26
- Add builds for additional architectures and operating systems